### PR TITLE
Fix C++23 build MSVC

### DIFF
--- a/komihash.h
+++ b/komihash.h
@@ -315,7 +315,7 @@
 	#define KOMIHASH_LIKELY( x ) ( __builtin_expect( x, 1 ))
 	#define KOMIHASH_UNLIKELY( x ) ( __builtin_expect( x, 0 ))
 
-#elif defined( __cplusplus ) && __cplusplus >= 202002L
+#elif defined( __cplusplus ) && __cplusplus >= 202002L && !defined( _MSC_VER )
 
 	#define KOMIHASH_LIKELY( x ) ( x ) [[likely]]
 	#define KOMIHASH_UNLIKELY( x ) ( x ) [[unlikely]]


### PR DESCRIPTION
Fixing the komihash build for MSVC of the current version with the C++23 standard enabled.

The current version of MSVC does not support constructions like
`do {} while (condition) [[likely]];`

This leads to compilation errors in the C++23 standard (__cplusplus >= 202002L):
```
komihash.h(872): error C2143: syntax error: missing ';' before 'attribute specifier'
komihash.h(1035): error C2143: syntax error: missing ';' before 'attribute specifier'
komihash.h(1119): error C2143: syntax error: missing ';' before 'attribute specifier'
```
Since [[likely]] has extremely limited support (close to useless) in actual versions of MSVC, and it is unknown when Microsoft will fix this, I suggest disabling the [[likely]] attributes for MSVC.